### PR TITLE
Translatable strings, toolbarload fix, proper css enqueue & options page fixes.

### DIFF
--- a/atbar.php
+++ b/atbar.php
@@ -21,14 +21,17 @@ include_once ('functions/atbarwidget.class.php');
 include(dirname(__FILE__).'/options.php');
 
 // adds css to header
-add_action('wp_print_styles', 'atbar_css');
+add_action('wp_enqueue_scripts', 'atbar_css');
 
 // adds the toolbar itself
-add_action('the_post', 'add_toolbar');
+add_action('get_header', 'add_toolbar');
 
 // adds ATbar widget
 add_action( 'widgets_init', create_function( '', 'register_widget( "atbar_widget" );' ) );
 
 // add ATbar shortcode - type [atbar] (uses the same settings as the other launchers - edit in settings)
 add_shortcode('atbar','shortcode_launcher');
+
+add_action('after_setup_theme', 'atbar_plugin_setup');
+
 ?>

--- a/functions/atbarwidget.class.php
+++ b/functions/atbarwidget.class.php
@@ -6,7 +6,7 @@ class ATbar_Widget extends WP_Widget{
 		parent::__construct(
 	 		'atbar_widget',
 			'ATbar',
-			array('description' => __( 'ATbar launcher. Loads the selected version of ATbar (settings->ATbar)'),)
+			array('description' => __( 'ATbar launcher. Loads the selected version of ATbar (settings->ATbar)', 'atbar'),)
 		);
 	}
 
@@ -34,11 +34,11 @@ class ATbar_Widget extends WP_Widget{
 			$title = $instance['title'];
 		}
 		else{
-			$title = __( 'New title', 'text_domain');
+			$title = __( 'New title', 'atbar');
 		}
 		?>
 		<p>
-		<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:' ); ?></label> 
+		<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'atbar' ); ?></label> 
 		<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 		</p>
 		<?php 
@@ -66,7 +66,7 @@ class ATbar_Widget extends WP_Widget{
 			break;
 		}
 		
-		$launcher = '<a href="'.$js.'" id="toolbar-launch" title="Launch ATbar to adjust this webpage, have it read aloud and other functions."><img src="https://core.atbar.org/resources/img/launcher.png" alt="ATbar"></a>';
+		$launcher = '<a href="'.$js.'" id="toolbar-launch" title="'.__('Launch ATbar to adjust this webpage, have it read aloud and other functions.', 'atbar').'"><img src="https://core.atbar.org/resources/img/launcher.png" alt="ATbar"></a>';
 		echo '<div id="toolbar-widget">'.$launcher.'</div>';
 	}
 

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -3,7 +3,8 @@
 // functions
 
 function atbar_css() {
-	echo ('<link rel="stylesheet" type="text/css" media="all" href="'.plugin_dir_url(__FILE__).'atbar.css">');
+    
+    wp_enqueue_style('atbar', plugin_dir_url(__FILE__).'atbar.css">');
 }
 
 function atbar_register_settings(){
@@ -19,7 +20,7 @@ function atbar_register_settings(){
 }
 
 function atbar_add_options(){
-	add_options_page('Atbar', 'Atbar', 'manage_options', 'atbaroptions', 'atbar_options');
+	add_options_page('ATbar', 'ATbar', 'manage_options', 'atbaroptions', 'atbar_options');
 }
 
 function is_version($value) {
@@ -82,7 +83,7 @@ function toolbarlauncher() {
 		break;
 	}
 	
-	$launcher = '<a href="'.$js.'" id="toolbar-launch" title="Launch ATbar to adjust this webpage, have it read aloud and other functions."><img src="https://core.atbar.org/resources/img/launcher.png" alt="ATbar"></a>';
+	$launcher = '<a href="'.$js.'" id="toolbar-launch" title="'.__('Launch ATbar to adjust this webpage, have it read aloud and other functions.', 'atbar').'"><img src="https://core.atbar.org/resources/img/launcher.png" alt="ATbar"></a>';
 	$launcher = addslashes($launcher);
 	
 	echo ('<script language="javascript">
@@ -175,13 +176,17 @@ function exclude_pages($setting, $pages, $function) {
 
 	if($exclude_option == "on") {
 		if(!in_array($postid, $array)) {
-			add_action('get_footer', $function);
+			add_action('wp_footer', $function);
 		}
 	}
 	else {
-		add_action('get_footer', $function);
+		add_action('wp_footer', $function);
 	}
 }
+function atbar_plugin_setup() {
+    load_plugin_textdomain('atbar', false, dirname(plugin_basename(__FILE__)) . '/lang/');
+} // end atbar_plugin_setup
+
 
 
 ?>

--- a/options.php
+++ b/options.php
@@ -17,111 +17,111 @@ function atbar_options()
 	
 	<div class="wrap">
 	<div id="icon-options-general" class="icon32"><br /></div>
-	<h2>Atbar Options</h2>
+	<h2><?php _e('ATbar Options','atbar');?></h2>
 	
 	<form method="post" action="options.php">
-	<? settings_fields("atbar_options"); ?>
+	<?php settings_fields("atbar_options"); ?>
 	
-	<p><b>For instructions on this plugin view the <a href="http://www.atbar.org/wordpress-plugin-guide">ATbar Wordpress Plugin Guide</a>.</b></p>
+	<p><b><?php _e('For instructions on this plugin view the <a href="http://www.atbar.org/wordpress-plugin-guide">ATbar Wordpress Plugin Guide</a>','atbar');?>.</b></p>
 	
-	<p>The ATbar sidebar widget can be added in Appearance, Widgets then adding ATbar to your active Widgets.</p>
+	<p><?php _e('The ATbar sidebar widget can be added in Appearance, Widgets then adding ATbar to your active Widgets.','atbar');?></p>
 	
 	
 	<table class="form-table">
 	
 		<!-- select version to use -->
 		<tr style="border-top: 1px solid #DFDFDF;">
-			<td><h3>Version</h3></td>
-			<td>Select which language version or if you want your own customised Marketplace toolbar. Create your own toolbar at <a href="http://marketplace.atbar.org">http://marketplace.atbar.org</a> or use one of the pre-made toolbars.</td>
+			<td><h3><?php _e('Version','atbar');?></h3></td>
+			<td><?php _e('Select which language version or if you want your own customised Marketplace toolbar. Create your own toolbar at <a href="http://marketplace.atbar.org">http://marketplace.atbar.org</a> or use one of the pre-made toolbars.','atbar');?></td>
 		</tr>
 		<tr>
-			<th scope="row">Select version:</th>
+			<th scope="row"><?php _e('Select version:','atbar');?></th>
 			<td>
 				<select name="atbar_version">
-					<option value="en"	<? echo is_version("en"); ?>>English</option>
-					<option value="ar" <? echo is_version("ar"); ?>>Arabic</option>
-					<option value="marketplace"	<? echo is_version("marketplace");	?>>Toolbar from ATbar Marketplace</option>
+					<option value="en"	<?php echo is_version("en"); ?>><?php _e('English','atbar');?></option>
+					<option value="ar" <?php echo is_version("ar"); ?>><?php _e('Arabic','atbar');?></option>
+					<option value="marketplace"	<?php echo is_version("marketplace");	?>><?php _e('Toolbar from ATbar Marketplace','atbar');?></option>
 				</select>
 			</td>
 		</tr>
-			<th>Toolbar from ATbar Marketplace:</th>
+			<th><?php _e('Toolbar from ATbar Marketplace:','atbar');?></th>
 			<td>
-				<input type="text" name="atbar_marketplace_toolbar" value="<? echo $marketplace_toolbar_option ?>" style="width:350px;">
-				<p>Copy the install button link in the text box (the full javascript string)</p>
-				<p>For further instructions view the <a href="http://www.atbar.org/wordpress-plugin-guide">guide</a>.</p>
+				<input type="text" name="atbar_marketplace_toolbar" value="<?php echo $marketplace_toolbar_option ?>" style="width:350px;">
+				<p><?php _e('Copy the install button link in the text box (the full javascript string)','atbar');?></p>
+				<p><?php _e('For further instructions view the <a href="http://www.atbar.org/wordpress-plugin-guide">guide</a>.','atbar');?></p>
 			</td>
 		</tr>
 		
 		<!-- load atbar launcher -->
 		<tr style="border-top: 1px solid #DFDFDF;">
-			<td><h3>ATbar Launcher</h3></td>
-			<td>The ATbar launcher is the default button/image at the top of the page and is the standard way of loading ATbar. If you have chosen to use the ATbar Widget or Shortcode else where you are unlikely to want this option on.</td>
+			<td><h3><?php _e('ATbar Launcher','atbar');?></h3></td>
+			<td><?php _e('The ATbar launcher is the default button/image at the top of the page and is the standard way of loading ATbar. If you have chosen to use the ATbar Widget or Shortcode else where you are unlikely to want this option on.','atbar');?></td>
 		</tr>
 		<tr>
-			<th scope="row">Load ATbar launcher at the top of the page?</th>
+			<th scope="row"><?php _e('Load ATbar launcher at the top of the page?','atbar');?></th>
 			<td>
 				<select name="atbar_launcher_image">
-						<option value="No" <? echo is_banner_show("No"); ?>>No</option>
-						<option value="Yes" <? echo is_banner_show("Yes");	?>>Yes</option>
+						<option value="No" <?php echo is_banner_show("No"); ?>><?php _e('No','atbar');?></option>
+						<option value="Yes" <?php echo is_banner_show("Yes");	?>><?php _e('Yes','atbar');?></option>
 				</select>
 			</td>
 		</tr>
 		
 		<!-- exclude pages for laucher -->
 		<tr>
-			<th scope="row">Exclude pages for ATbar launcher?</th>
-			<td><input type="checkbox" name="atbar_launcher_exclude" lable="exclude pages for launcher" <? is_exclude('atbar_launcher_exclude'); ?>>  Exclude pages for ATbar launcher</td>
+			<th scope="row"><?php _e('Exclude pages for ATbar launcher?','atbar');?></th>
+			<td><input type="checkbox" name="atbar_launcher_exclude" label="exclude pages for launcher" <?php echo is_exclude('atbar_launcher_exclude'); ?>>  <?php _e('Exclude pages for ATbar launcher','atbar');?></td>
 		</tr>
 		<tr>
 			<td></td>
 			<td>
-				<input type="text" name="atbar_launcher_exclude_pages" value="<? echo $exclude_launcher_pages_option; ?>" style="width:346px;">
-				<p>Enter a comma-separated list of page IDs or name to exclude, e.g. 1,2,3 etc.</p>
+				<input type="text" name="atbar_launcher_exclude_pages" value="<?php echo $exclude_launcher_pages_option; ?>" style="width:346px;">
+				<p><?php _e('Enter a comma-separated list of page IDs or name to exclude, e.g. 1,2,3 etc.','atbar');?></p>
 			</td>
 		</tr>
 		
 		<!-- auto load atbar -->		
 		<tr style="border-top: 1px solid #DFDFDF;">
-			<td><h3>Auto Load ATbar?</h3></td>
-			<td>These settings will allows ATbar to be loaded on all pages automatically. Any number of pages can be excluded.</td>
+			<td><h3><?php _e('Auto Load ATbar?','atbar');?></h3></td>
+			<td><?php _e('These settings will allows ATbar to be loaded on all pages automatically. Any number of pages can be excluded.','atbar');?></td>
 		</tr>
 		<tr>
-			<th scope="row">Auto load ATbar on all pages? (user doesn't have to select to load each time)</th>
+			<th scope="row"><?php _e('Auto load ATbar on all pages? (user doesn\'t have to select to load each time)','atbar');?></th>
 			<td>
 				<select name="atbar_persistent">
-					<option value="No" <? echo is_persistent("No"); ?>>No</option>
-					<option value="Yes" <? echo is_persistent("Yes"); ?>>Yes</option>
+					<option value="No" <?php echo is_persistent("No"); ?>><?php _e('No','atbar');?></option>
+					<option value="Yes" <?php echo is_persistent("Yes"); ?>><?php _e('Yes','atbar');?></option>
 				</select>
 			</td>
 		</tr>
 		
 		<!-- exclude pages for auto loader -->
 		<tr>
-			<th scope="row">Exclude pages for auto load?</th>
-			<td><input type="checkbox" name="atbar_exclude" lable="exclude pages for auto loader" <? is_exclude('atbar_exclude'); ?>>  Exclude pages for auto load</td>
+			<th scope="row"><?php _e('Exclude pages for auto load?','atbar');?></th>
+			<td><input type="checkbox" name="atbar_exclude" lable="exclude pages for auto loader" <?php echo is_exclude('atbar_exclude'); ?>>  <?php _e('Exclude pages for auto load','atbar');?></td>
 		</tr>
 				
 		<tr>
 			<td></td>
 			<td>
-				<input type="text" name="atbar_exclude_pages" value="<? echo $exclude_pages_option; ?>" style="width:346px;">
-				<p>Enter a comma-separated list of page IDs or name to exclude, e.g. 1,2,3 etc.</p>
+				<input type="text" name="atbar_exclude_pages" value="<?php echo $exclude_pages_option; ?>" style="width:346px;">
+				<p><?php _e('Enter a comma-separated list of page IDs or name to exclude, e.g. 1,2,3 etc.','atbar');?></p>
 			</td>
 		</tr>
 		
 		<!-- shortcode options -->			
 		<tr style="border-top: 1px solid #DFDFDF;">
-			<td><h3>Shortcode</h3></td>
-			<td>Shortcodes are a short piece of text to place in a post or page to run a command. In ATbar's case it will add the ATbar launcher image whereever you place <i>[atbar]</i></td>
+			<td><h3><?php _e('Shortcode','atbar');?></h3></td>
+			<td><?php _e('Shortcodes are a short piece of text to place in a post or page to run a command. In ATbar\'s case it will add the ATbar launcher image whereever you place','atbar');?> <i>[atbar]</i></td>
 		</tr>
 		<tr>
-			<th scope="row">Align position</th>
+			<th scope="row"><?php _e('Align position','atbar');?></th>
 			
 			<td>
 				<select name="atbar_shortcode_align_option">
-					<option value="left"	<? echo is_sc_align("left"); ?>>Left</option>
-					<option value="center" <? echo is_sc_align("center"); ?>>Center</option>
-					<option value="right" <? echo is_sc_align("right"); ?>>Right</option>
+					<option value="left"	<?php echo is_sc_align("left"); ?>><?php _e('Left','atbar');?></option>
+					<option value="center" <?php echo is_sc_align("center"); ?>><?php _e('Center','atbar');?></option>
+					<option value="right" <?php echo is_sc_align("right"); ?>><?php _e('Right','atbar');?></option>
 				</select>
 			</td>
 		</tr>
@@ -130,15 +130,15 @@ function atbar_options()
 		<tr valign="top">
 			<th scope="row">
 				<p class="submit">
-					<input type="submit" class="button-primary" style="float:left" value="Save Changes" />
+					<input type="submit" class="button-primary" style="float:left" value="<?php _e('Save Changes','atbar');?>" />
 				</p>
 			</th>
 		</tr>
 		</form>
 		
 		<form method="post" action="options.php">
-			<? settings_fields('atbar_options'); ?>
-			<input type="hidden" name="atbar_persistent" value="<? get_option('atbar_persistent') ?>" />
+			<?php settings_fields('atbar_options'); ?>
+			<input type="hidden" name="atbar_persistent" value="<?php get_option('atbar_persistent') ?>" />
 		</form>	
 
 	</table>


### PR DESCRIPTION
I added some fixes for this plugin to bring it more inline with WordPress development guidelines. Of note, the plugin wasn't showing the loader toolbar on WP 4.0.1 (and possibly previous versions). We've been working on some Southampton University WordPress projects recently (Are You Ready/Opus/We Are Connected/Cancer Immunology Centre) which is why this repo drew my attention.

Made text strings translatable & created lang directory for textdomain 'atbar'
Case correction on some strings (from Atbar to ATbar)
Fixed toolbar loading action (from get_footer to wp_footer).
Fixed checked/unchecked of 'exclude' boxes on options page.
Properly enqueued CSS file using wp_enqueue_style & added appropriate action.
